### PR TITLE
Exclude testing-library/react from bumps in ts4-react177 folder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,3 +78,4 @@ updates:
       - dependency-name: "@types/react*"
       # also ignore typescript again because this particular folder is testing compatibility with old typescript version
       - dependency-name: "typescript"
+      - dependency-name: "@testing-library/react"


### PR DESCRIPTION
 because the bump fails tests https://github.com/recharts/recharts-integ/actions/runs/14715475061/job/41297723048?pr=38