### PR TITLE
Add an integration test for a library inside of a library

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -24,6 +24,8 @@ jobs:
           - integrations-yarn/ts4-react17
           - integrations-yarn/ts-react18
           - integrations-yarn/ts-react19
+          # the "library inside library" test fails so let's not run it for now
+          # - integrations-library-inside-library
     steps:
       - uses: actions/checkout@v3
       - name: Setup node.js

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules
 .DS_Store
 dist
 /.idea/*
+
+# we don't want to commit lock files for the integration tests, we want to have a fresh install always
+package-lock.json
+yarn.lock

--- a/integrations-library-inside-library/app/.gitignore
+++ b/integrations-library-inside-library/app/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/integrations-library-inside-library/app/README.md
+++ b/integrations-library-inside-library/app/README.md
@@ -1,0 +1,54 @@
+# React + TypeScript + Vite
+
+This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+
+Currently, two official plugins are available:
+
+- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
+- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## Expanding the ESLint configuration
+
+If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+
+```js
+export default tseslint.config({
+  extends: [
+    // Remove ...tseslint.configs.recommended and replace with this
+    ...tseslint.configs.recommendedTypeChecked,
+    // Alternatively, use this for stricter rules
+    ...tseslint.configs.strictTypeChecked,
+    // Optionally, add this for stylistic rules
+    ...tseslint.configs.stylisticTypeChecked,
+  ],
+  languageOptions: {
+    // other options...
+    parserOptions: {
+      project: ['./tsconfig.node.json', './tsconfig.app.json'],
+      tsconfigRootDir: import.meta.dirname,
+    },
+  },
+})
+```
+
+You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+
+```js
+// eslint.config.js
+import reactX from 'eslint-plugin-react-x'
+import reactDom from 'eslint-plugin-react-dom'
+
+export default tseslint.config({
+  plugins: {
+    // Add the react-x and react-dom plugins
+    'react-x': reactX,
+    'react-dom': reactDom,
+  },
+  rules: {
+    // other rules...
+    // Enable its recommended typescript rules
+    ...reactX.configs['recommended-typescript'].rules,
+    ...reactDom.configs.recommended.rules,
+  },
+})
+```

--- a/integrations-library-inside-library/app/eslint.config.js
+++ b/integrations-library-inside-library/app/eslint.config.js
@@ -1,0 +1,28 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+    },
+  },
+)

--- a/integrations-library-inside-library/app/index.html
+++ b/integrations-library-inside-library/app/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/integrations-library-inside-library/app/package.json
+++ b/integrations-library-inside-library/app/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview",
+    "test": "vitest --run"
+  },
+  "dependencies": {
+    "my-charts": "file:../my-charts",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.25.0",
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-react": "^4.4.1",
+    "eslint": "^9.25.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.19",
+    "globals": "^16.0.0",
+    "jsdom": "^26.1.0",
+    "typescript": "~5.8.3",
+    "typescript-eslint": "^8.30.1",
+    "vite": "^6.3.5",
+    "vitest": "^3.1.3"
+  }
+}

--- a/integrations-library-inside-library/app/src/App.spec.tsx
+++ b/integrations-library-inside-library/app/src/App.spec.tsx
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import App from './App'
+import { render } from '@testing-library/react'
+
+describe('App', () => {
+    it('should render svg and two bars', async () => {
+        const { container } = render(<App />)
+        const svg = container.getElementsByTagName('svg')[0]
+        expect(svg).toBeDefined()
+        const bars = container.getElementsByClassName('recharts-bar-rectangle')
+        expect(bars).toHaveLength(2)
+    })
+})

--- a/integrations-library-inside-library/app/src/App.tsx
+++ b/integrations-library-inside-library/app/src/App.tsx
@@ -1,0 +1,11 @@
+// @ts-expect-error my-charts does not have types
+import { MyChart } from 'my-charts'
+
+function App() {
+
+  return (
+    <MyChart />
+  )
+}
+
+export default App

--- a/integrations-library-inside-library/app/src/index.css
+++ b/integrations-library-inside-library/app/src/index.css
@@ -1,0 +1,68 @@
+:root {
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+
+  color-scheme: light dark;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  font-weight: 500;
+  color: #646cff;
+  text-decoration: inherit;
+}
+a:hover {
+  color: #535bf2;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  place-items: center;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+h1 {
+  font-size: 3.2em;
+  line-height: 1.1;
+}
+
+button {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #1a1a1a;
+  cursor: pointer;
+  transition: border-color 0.25s;
+}
+button:hover {
+  border-color: #646cff;
+}
+button:focus,
+button:focus-visible {
+  outline: 4px auto -webkit-focus-ring-color;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #213547;
+    background-color: #ffffff;
+  }
+  a:hover {
+    color: #747bff;
+  }
+  button {
+    background-color: #f9f9f9;
+  }
+}

--- a/integrations-library-inside-library/app/src/main.tsx
+++ b/integrations-library-inside-library/app/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/integrations-library-inside-library/app/src/vite-env.d.ts
+++ b/integrations-library-inside-library/app/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/integrations-library-inside-library/app/tsconfig.app.json
+++ b/integrations-library-inside-library/app/tsconfig.app.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/integrations-library-inside-library/app/tsconfig.json
+++ b/integrations-library-inside-library/app/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/integrations-library-inside-library/app/tsconfig.node.json
+++ b/integrations-library-inside-library/app/tsconfig.node.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/integrations-library-inside-library/app/vite.config.ts
+++ b/integrations-library-inside-library/app/vite.config.ts
@@ -1,0 +1,11 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom'
+  }
+})

--- a/integrations-library-inside-library/my-charts/.babelrc
+++ b/integrations-library-inside-library/my-charts/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": [
+    ["@babel/preset-env", { "modules": false }],
+    ["@babel/preset-react", { "runtime": "automatic" }]
+  ]
+}

--- a/integrations-library-inside-library/my-charts/package.json
+++ b/integrations-library-inside-library/my-charts/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "my-charts",
+  "version": "0.1.0",
+  "description": "A trivial React component library wrapping Recharts BarChart.",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "babel src -d dist --copy-files",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "recharts": "^3.0.0-beta.0"
+  },
+  "keywords": [
+    "react",
+    "recharts",
+    "chart",
+    "component"
+  ],
+  "author": "Pavel Vanecek",
+  "license": "MIT",
+  "devDependencies": {
+    "@babel/cli": "^7.27.2",
+    "@babel/core": "^7.27.1",
+    "@babel/preset-env": "^7.27.2",
+    "@babel/preset-react": "^7.27.1"
+  }
+}

--- a/integrations-library-inside-library/my-charts/src/index.jsx
+++ b/integrations-library-inside-library/my-charts/src/index.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {BarChart, XAxis, YAxis, Bar, Legend, Tooltip} from 'recharts';
+
+/**
+ * MyChart Component
+ *
+ * A wrapper around the Recharts BarChart component.
+ * It accepts all props that BarChart accepts and passes them through.
+ *
+ * @param {object} props - The props to pass to the BarChart component.
+ * @param {React.ReactNode} props.children - The children elements for the chart (e.g., XAxis, YAxis, Bar).
+ * @returns {JSX.Element} The BarChart component with the provided props and children.
+ */
+export const MyChart = (props) => {
+    // Destructure children and other props
+    const {children, ...rest} = props;
+
+    // Render the Recharts BarChart with all passed props and children
+    return (
+        <BarChart
+            width={600}
+            height={300}
+            data={[
+                {name: 'A', value: 100},
+                {name: 'B', value: 200},
+            ]}{...rest}
+        >
+            <XAxis dataKey="name"/>
+            <YAxis/>
+            <Bar dataKey="value" fill="gold" name="Tooltip value"/>
+            <Legend/>
+            <Tooltip/>
+            {children}
+        </BarChart>
+    );
+};


### PR DESCRIPTION
github.com/recharts/recharts/discussions/5701

Also this comment in particular: https://github.com/recharts/recharts/issues/5445#issuecomment-2822103625

There are still some things left to do, in followup PRs:
- there is only one test now (with npm + react 19), we should have multiple (as the bug report was specifically mentioning React 18)
- have a bit of structure, DRY
- support replacing the hardcoded version with an argument (for the tgz file)
- actually fix the failing test (I suspect this is a signal, and an argument for why the peerDependencies will be necessary after all - more testing required here)