### PR TITLE
Update CI triggers to only run on main branch for pull requests and pushes

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -3,7 +3,13 @@
 
 name: Recharts integration tests
 
-on: [ push, pull_request ]
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   list_integration_tests:


### PR DESCRIPTION
All the tests used to run twice on PR, that is not necessary and it just adds noise and wastes CI minutes.