### PR TITLE
Pin @preact/preset-vite to 2.10.3 to fix astro-preact build

### DIFF
--- a/integrations/astro-preact/package.json
+++ b/integrations/astro-preact/package.json
@@ -13,5 +13,8 @@
     "astro": "^5.16.7",
     "preact": "^10.28.2",
     "recharts": "latest"
+  },
+  "overrides": {
+    "@preact/preset-vite": "2.10.3"
   }
 }


### PR DESCRIPTION
Caused by https://github.com/preactjs/preset-vite/issues/193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added dependency override for the astro-preact integration to ensure consistent version resolution during package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->