### PR TITLE
vite 8.0.16 still works

### DIFF
--- a/integrations/vite8-react19/package.json
+++ b/integrations/vite8-react19/package.json
@@ -31,7 +31,7 @@
     "jsdom": "^26.1.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "8.0.13",
+    "vite": "8.0.16",
     "vitest": "~4.0.15"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Vite dependency to the latest patch version in the Vite 8 React 19 integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->