### PR TITLE
Add Deno integration test

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: stable
+          deno-version: v2.x
 
       - name: Test app and check dependencies
         run: ./run-test.sh "${{ matrix.test_dir }}"

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -65,10 +65,15 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
         with:
           version: 10
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: lts
 
       - name: Test app and check dependencies
         run: ./run-test.sh "${{ matrix.test_dir }}"

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: lts
+          deno-version: stable
 
       - name: Test app and check dependencies
         run: ./run-test.sh "${{ matrix.test_dir }}"

--- a/integrations/deno-react19-package-json/.gitignore
+++ b/integrations/deno-react19-package-json/.gitignore
@@ -1,0 +1,3 @@
+deno.lock
+node_modules/
+package-lock.json

--- a/integrations/deno-react19-package-json/README.md
+++ b/integrations/deno-react19-package-json/README.md
@@ -1,0 +1,17 @@
+# Deno + package.json + React 19 + Recharts
+
+Integration test that verifies Recharts renders under [Deno](https://deno.com)
+when dependencies are declared in a **`package.json`** (Deno's npm-compatibility
+mode) rather than `deno.json` imports.
+
+This complements `deno-react19` (which uses `deno.json` + `npm:` specifiers) by
+exercising Deno's other dependency-resolution path. It renders a `BarChart` with
+`@testing-library/react` in a jsdom environment and asserts that an `<svg>` plus
+the expected bar rectangles are produced.
+
+## Run
+
+```sh
+deno install
+deno task test
+```

--- a/integrations/deno-react19-package-json/deno.json
+++ b/integrations/deno-react19-package-json/deno.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "jsxImportSourceTypes": "@types/react",
+    "lib": ["deno.window", "dom", "dom.iterable", "dom.asynciterable"]
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1"
+  },
+  "nodeModulesDir": "auto",
+  "tasks": {
+    "test": "deno test -A"
+  }
+}

--- a/integrations/deno-react19-package-json/package.json
+++ b/integrations/deno-react19-package-json/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "deno-react19-package-json",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "recharts": "latest"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^19.2.5",
+    "@types/react-dom": "^19.2.3",
+    "global-jsdom": "^26.0.0"
+  }
+}

--- a/integrations/deno-react19-package-json/src/App.test.tsx
+++ b/integrations/deno-react19-package-json/src/App.test.tsx
@@ -1,12 +1,20 @@
 import 'global-jsdom/register';
-import { render } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import { assert, assertEquals } from '@std/assert';
 import App from './App.tsx';
 
-Deno.test('should render svg and bars', () => {
+Deno.test('should render svg and bars', async () => {
     const { container } = render(<App />);
     const svg = container.getElementsByTagName('svg')[0];
     assert(svg, 'expected an <svg> to be rendered');
     const bars = container.getElementsByClassName('recharts-bar-rectangle');
     assertEquals(bars.length, 4);
+    cleanup();
+    // Recharts dispatches through Redux Toolkit's autoBatchEnhancer, which
+    // schedules a requestAnimationFrame plus a 100ms setTimeout fallback per
+    // notification. Let those settle, then close the jsdom window so its
+    // remaining timers are cleared — otherwise Deno's test sanitizer reports
+    // them as leaks.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    window.close();
 });

--- a/integrations/deno-react19-package-json/src/App.test.tsx
+++ b/integrations/deno-react19-package-json/src/App.test.tsx
@@ -1,0 +1,12 @@
+import 'global-jsdom/register';
+import { render } from '@testing-library/react';
+import { assert, assertEquals } from '@std/assert';
+import App from './App.tsx';
+
+Deno.test('should render svg and bars', () => {
+    const { container } = render(<App />);
+    const svg = container.getElementsByTagName('svg')[0];
+    assert(svg, 'expected an <svg> to be rendered');
+    const bars = container.getElementsByClassName('recharts-bar-rectangle');
+    assertEquals(bars.length, 4);
+});

--- a/integrations/deno-react19-package-json/src/App.tsx
+++ b/integrations/deno-react19-package-json/src/App.tsx
@@ -1,0 +1,28 @@
+import { Bar, BarChart, BarStack, Legend, Tooltip, XAxis, YAxis } from 'recharts';
+
+function App() {
+    return (
+        <>
+            <h1>Deno + package.json + React 19 + TypeScript + Recharts</h1>
+            <BarChart
+                width={600}
+                height={300}
+                data={[
+                    { name: 'A', value1: 100, value2: 50 },
+                    { name: 'B', value1: 200, value2: 130 },
+                ]}
+            >
+                <XAxis dataKey="name" />
+                <YAxis />
+                <BarStack>
+                    <Bar dataKey="value1" fill="gold" name="Tooltip value 1" />
+                    <Bar dataKey="value2" fill="silver" name="Tooltip value 2" />
+                </BarStack>
+                <Legend />
+                <Tooltip />
+            </BarChart>
+        </>
+    );
+}
+
+export default App;

--- a/integrations/deno-react19/.gitignore
+++ b/integrations/deno-react19/.gitignore
@@ -1,0 +1,2 @@
+deno.lock
+node_modules/

--- a/integrations/deno-react19/README.md
+++ b/integrations/deno-react19/README.md
@@ -1,0 +1,16 @@
+# Deno + React 19 + Recharts
+
+Integration test that verifies Recharts renders under [Deno](https://deno.com)
+using `npm:` specifiers (no `npm install` / `node_modules` required).
+
+It renders a `BarChart` with `@testing-library/react` in a jsdom environment and
+asserts that an `<svg>` and the expected bar rectangles are produced.
+
+## Run
+
+```sh
+deno task test
+```
+
+Deno reads dependencies from `deno.json` and resolves `react`, `react-dom`,
+`recharts`, and `@testing-library/react` straight from npm.

--- a/integrations/deno-react19/deno.json
+++ b/integrations/deno-react19/deno.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "jsxImportSourceTypes": "@types/react",
+    "lib": ["deno.window", "dom", "dom.iterable", "dom.asynciterable"]
+  },
+  "imports": {
+    "react": "npm:react@^19.2.0",
+    "react-dom": "npm:react-dom@^19.2.0",
+    "@types/react": "npm:@types/react@^19.2.5",
+    "@types/react-dom": "npm:@types/react-dom@^19.2.3",
+    "recharts": "npm:recharts@latest",
+    "@testing-library/react": "npm:@testing-library/react@^16.3.0",
+    "global-jsdom": "npm:global-jsdom@^26.0.0",
+    "@std/assert": "jsr:@std/assert@^1"
+  },
+  "tasks": {
+    "test": "deno test -A"
+  }
+}

--- a/integrations/deno-react19/src/App.test.tsx
+++ b/integrations/deno-react19/src/App.test.tsx
@@ -1,12 +1,20 @@
 import 'global-jsdom/register';
-import { render } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import { assert, assertEquals } from '@std/assert';
 import App from './App.tsx';
 
-Deno.test('should render svg and bars', () => {
+Deno.test('should render svg and bars', async () => {
     const { container } = render(<App />);
     const svg = container.getElementsByTagName('svg')[0];
     assert(svg, 'expected an <svg> to be rendered');
     const bars = container.getElementsByClassName('recharts-bar-rectangle');
     assertEquals(bars.length, 4);
+    cleanup();
+    // Recharts dispatches through Redux Toolkit's autoBatchEnhancer, which
+    // schedules a requestAnimationFrame plus a 100ms setTimeout fallback per
+    // notification. Let those settle, then close the jsdom window so its
+    // remaining timers are cleared — otherwise Deno's test sanitizer reports
+    // them as leaks.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    window.close();
 });

--- a/integrations/deno-react19/src/App.test.tsx
+++ b/integrations/deno-react19/src/App.test.tsx
@@ -1,0 +1,12 @@
+import 'global-jsdom/register';
+import { render } from '@testing-library/react';
+import { assert, assertEquals } from '@std/assert';
+import App from './App.tsx';
+
+Deno.test('should render svg and bars', () => {
+    const { container } = render(<App />);
+    const svg = container.getElementsByTagName('svg')[0];
+    assert(svg, 'expected an <svg> to be rendered');
+    const bars = container.getElementsByClassName('recharts-bar-rectangle');
+    assertEquals(bars.length, 4);
+});

--- a/integrations/deno-react19/src/App.tsx
+++ b/integrations/deno-react19/src/App.tsx
@@ -1,0 +1,28 @@
+import { Bar, BarChart, BarStack, Legend, Tooltip, XAxis, YAxis } from 'recharts';
+
+function App() {
+    return (
+        <>
+            <h1>Deno + React 19 + TypeScript + Recharts</h1>
+            <BarChart
+                width={600}
+                height={300}
+                data={[
+                    { name: 'A', value1: 100, value2: 50 },
+                    { name: 'B', value1: 200, value2: 130 },
+                ]}
+            >
+                <XAxis dataKey="name" />
+                <YAxis />
+                <BarStack>
+                    <Bar dataKey="value1" fill="gold" name="Tooltip value 1" />
+                    <Bar dataKey="value2" fill="silver" name="Tooltip value 2" />
+                </BarStack>
+                <Legend />
+                <Tooltip />
+            </BarChart>
+        </>
+    );
+}
+
+export default App;

--- a/scripts/run.mts
+++ b/scripts/run.mts
@@ -136,6 +136,9 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     if (errors.length > 0) {
         errors.forEach(result => {
             console.error(`❌ ${result.name}: ${result.error}`);
+            if (result.output) {
+                console.error(result.output);
+            }
         });
         process.exit(1);
     }

--- a/scripts/run.mts
+++ b/scripts/run.mts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "url";
 import { NpmController } from "../test-ui/server/scripts/NpmController.ts";
 import { YarnController } from "../test-ui/server/scripts/YarnController.ts";
 import { PnpmController } from "../test-ui/server/scripts/PnpmController.ts";
+import { DenoController } from "../test-ui/server/scripts/DenoController.ts";
 import type { Controller } from "../test-ui/server/scripts/Controller.ts";
 import type { TestOutcome } from "../test-ui/server/scripts/TestOutcome.ts";
 import {getTestMetadata} from "../test-ui/server/scripts/test-registry.ts";
@@ -64,13 +65,15 @@ async function runLibraryInLibraryTest(libController: Controller, appController:
     return results;
 }
 
-function getControllerConstructor(packageManager: string): typeof NpmController | typeof YarnController | typeof PnpmController {
+function getControllerConstructor(packageManager: string): typeof NpmController | typeof YarnController | typeof PnpmController | typeof DenoController {
     if (packageManager === "npm") {
         return NpmController;
     } else if (packageManager === "yarn") {
         return YarnController;
     } else if (packageManager === "pnpm") {
         return PnpmController;
+    } else if (packageManager === "deno") {
+        return DenoController;
     } else {
         throw new Error(`Unknown package manager: ${packageManager}`);
     }

--- a/test-ui/server/scripts/DenoController.ts
+++ b/test-ui/server/scripts/DenoController.ts
@@ -1,0 +1,103 @@
+import fs from "fs";
+import path from "path";
+import { Controller } from "./Controller.ts";
+import { TestOutcome } from "./TestOutcome.ts";
+
+export class DenoController extends Controller {
+  // Deno resolves modules through its own cache (DENO_DIR / HOME), so those need
+  // to be forwarded on top of the base environment.
+  override getEnv(): NodeJS.ProcessEnv {
+    return {
+      ...super.getEnv(),
+      HOME: process.env.HOME,
+      DENO_DIR: process.env.DENO_DIR,
+    };
+  }
+
+  async install(): Promise<TestOutcome> {
+    try {
+      await this.execAsync("deno install");
+      return TestOutcome.ok("install");
+    } catch (ex: unknown) {
+      return TestOutcome.fail("install", ex);
+    }
+  }
+
+  async test(): Promise<TestOutcome> {
+    try {
+      await this.execAsync("deno task test");
+      return TestOutcome.ok("unit test");
+    } catch (ex) {
+      return TestOutcome.fail("unit test", ex as Error);
+    }
+  }
+
+  async build(): Promise<TestOutcome> {
+    // Deno runs TypeScript directly, so there is no bundling step; type-check
+    // the project as the equivalent "build" verification.
+    try {
+      await this.execAsync("deno check src/App.test.tsx");
+      return TestOutcome.ok("build");
+    } catch (ex) {
+      console.error(ex);
+      return TestOutcome.fail("build", ex as Error);
+    }
+  }
+
+  async pack(): Promise<string> {
+    throw new Error("pack is not supported for Deno integrations");
+  }
+
+  async verifySingleDependencyVersion(
+    dependencyName: string,
+  ): Promise<TestOutcome> {
+    const lockPath = path.join(this.absolutePath, "deno.lock");
+
+    let lock: any;
+    try {
+      lock = JSON.parse(fs.readFileSync(lockPath, "utf-8"));
+    } catch (ex) {
+      return TestOutcome.fail(
+        dependencyName,
+        new Error("Failed to read or parse deno.lock"),
+      );
+    }
+
+    // deno.lock npm keys look like `react@19.2.7` or, with peer dependencies,
+    // `recharts@3.8.1_react@19.2.7_react-dom@19.2.7__react@19.2.7`. Strip the
+    // peer-dependency suffix, then split the name from the version on the last
+    // `@` (so scoped packages like `@scope/name@1.2.3` work too).
+    const installedVersions = new Set<string>();
+    for (const key of Object.keys(lock.npm ?? {})) {
+      const base = key.split("_")[0];
+      const at = base.lastIndexOf("@");
+      if (at <= 0) continue;
+      const name = base.slice(0, at);
+      const version = base.slice(at + 1);
+      if (name === dependencyName) {
+        installedVersions.add(version);
+      }
+    }
+
+    if (installedVersions.size === 0) {
+      return TestOutcome.fail(
+        dependencyName,
+        new Error(`Dependency ${dependencyName} is not installed`),
+      );
+    }
+
+    if (installedVersions.size > 1) {
+      return TestOutcome.fail(
+        dependencyName,
+        new Error(
+          `Multiple versions of ${dependencyName} are installed: ${Array.from(installedVersions).join(", ")}`,
+        ),
+      );
+    }
+
+    return TestOutcome.ok(
+      "verify",
+      `Dependency ${dependencyName} is installed and only one version is present: ${Array.from(installedVersions).join(", ")}`,
+    );
+  }
+}

--- a/test-ui/server/scripts/DenoController.ts
+++ b/test-ui/server/scripts/DenoController.ts
@@ -14,6 +14,44 @@ export class DenoController extends Controller {
     };
   }
 
+  // Deno keeps dependencies in `deno.json` (under `imports`) rather than a
+  // `package.json`, so the recharts version under test is patched there.
+  override replacePackageJsonVersion(
+    dependencyName: string,
+    version: string,
+  ): TestOutcome {
+    if (version == null || version === "") {
+      return TestOutcome.ok("replace-package-version");
+    }
+
+    const denoJsonPath = path.join(this.absolutePath, "deno.json");
+    let denoJson: { imports?: Record<string, string>; [key: string]: unknown };
+    try {
+      denoJson = JSON.parse(fs.readFileSync(denoJsonPath, "utf8"));
+    } catch (error) {
+      return TestOutcome.fail(
+        "replace-package-version",
+        new Error(`Failed to read ${denoJsonPath}: ${error}`),
+      );
+    }
+
+    if (denoJson.imports?.[dependencyName]) {
+      // `version` may be a plain version ("3.8.2"), a `file:` tarball, or an
+      // already-prefixed specifier; only bare versions need the `npm:` prefix.
+      const specifier =
+        version.startsWith("npm:") ||
+        version.startsWith("jsr:") ||
+        version.startsWith("file:") ||
+        version.startsWith("http")
+          ? version
+          : `npm:${dependencyName}@${version}`;
+      denoJson.imports[dependencyName] = specifier;
+      fs.writeFileSync(denoJsonPath, JSON.stringify(denoJson, null, 2) + "\n");
+    }
+
+    return TestOutcome.ok("replace-package-version");
+  }
+
   async install(): Promise<TestOutcome> {
     try {
       await this.execAsync("deno install");

--- a/test-ui/server/scripts/DenoController.ts
+++ b/test-ui/server/scripts/DenoController.ts
@@ -14,8 +14,9 @@ export class DenoController extends Controller {
     };
   }
 
-  // Deno keeps dependencies in `deno.json` (under `imports`) rather than a
-  // `package.json`, so the recharts version under test is patched there.
+  // Deno reads both `deno.json` (`imports`) and `package.json`. When the
+  // dependency is declared in `deno.json` imports, patch the specifier there;
+  // otherwise fall back to the base `package.json` implementation.
   override replacePackageJsonVersion(
     dependencyName: string,
     version: string,
@@ -25,31 +26,41 @@ export class DenoController extends Controller {
     }
 
     const denoJsonPath = path.join(this.absolutePath, "deno.json");
-    let denoJson: { imports?: Record<string, string>; [key: string]: unknown };
-    try {
-      denoJson = JSON.parse(fs.readFileSync(denoJsonPath, "utf8"));
-    } catch (error) {
-      return TestOutcome.fail(
-        "replace-package-version",
-        new Error(`Failed to read ${denoJsonPath}: ${error}`),
-      );
+    if (fs.existsSync(denoJsonPath)) {
+      let denoJson: {
+        imports?: Record<string, string>;
+        [key: string]: unknown;
+      };
+      try {
+        denoJson = JSON.parse(fs.readFileSync(denoJsonPath, "utf8"));
+      } catch (error) {
+        return TestOutcome.fail(
+          "replace-package-version",
+          new Error(`Failed to read ${denoJsonPath}: ${error}`),
+        );
+      }
+
+      if (denoJson.imports?.[dependencyName]) {
+        // `version` may be a plain version ("3.8.2"), a `file:` tarball, or an
+        // already-prefixed specifier; only bare versions need the `npm:` prefix.
+        const specifier =
+          version.startsWith("npm:") ||
+          version.startsWith("jsr:") ||
+          version.startsWith("file:") ||
+          version.startsWith("http")
+            ? version
+            : `npm:${dependencyName}@${version}`;
+        denoJson.imports[dependencyName] = specifier;
+        fs.writeFileSync(
+          denoJsonPath,
+          JSON.stringify(denoJson, null, 2) + "\n",
+        );
+        return TestOutcome.ok("replace-package-version");
+      }
     }
 
-    if (denoJson.imports?.[dependencyName]) {
-      // `version` may be a plain version ("3.8.2"), a `file:` tarball, or an
-      // already-prefixed specifier; only bare versions need the `npm:` prefix.
-      const specifier =
-        version.startsWith("npm:") ||
-        version.startsWith("jsr:") ||
-        version.startsWith("file:") ||
-        version.startsWith("http")
-          ? version
-          : `npm:${dependencyName}@${version}`;
-      denoJson.imports[dependencyName] = specifier;
-      fs.writeFileSync(denoJsonPath, JSON.stringify(denoJson, null, 2) + "\n");
-    }
-
-    return TestOutcome.ok("replace-package-version");
+    // Dependency is managed via package.json, which Deno also reads.
+    return super.replacePackageJsonVersion(dependencyName, version);
   }
 
   async install(): Promise<TestOutcome> {

--- a/test-ui/server/scripts/test-registry.ts
+++ b/test-ui/server/scripts/test-registry.ts
@@ -5,7 +5,7 @@
  * All test definitions, metadata, and execution logic should reference this registry.
  */
 
-export type PackageManager = "npm" | "yarn" | "pnpm";
+export type PackageManager = "npm" | "yarn" | "pnpm" | "deno";
 export type TestType = "direct" | "library";
 export type TestStability = "stable" | "experimental";
 
@@ -39,6 +39,15 @@ export interface TestRegistry {
 
 // Define all direct dependency tests
 const directDependencyTests: TestMetadata[] = [
+  {
+    name: "Deno + React 19",
+    description: "Verifies Recharts renders under Deno using npm: specifiers",
+    stability: "stable",
+    type: "direct",
+    packageManager: "deno",
+    integrationPath: "integrations/deno-react19",
+    dependencies: { react: "19" },
+  },
   // npm direct dependency tests
   {
     name: "npm:integrations/tanstack-start-basic",

--- a/test-ui/server/scripts/test-registry.ts
+++ b/test-ui/server/scripts/test-registry.ts
@@ -40,12 +40,23 @@ export interface TestRegistry {
 // Define all direct dependency tests
 const directDependencyTests: TestMetadata[] = [
   {
-    name: "Deno + React 19",
-    description: "Verifies Recharts renders under Deno using npm: specifiers",
+    name: "Deno + React 19 (deno.json)",
+    description:
+      "Verifies Recharts renders under Deno with dependencies in deno.json (npm: specifiers)",
     stability: "stable",
     type: "direct",
     packageManager: "deno",
     integrationPath: "integrations/deno-react19",
+    dependencies: { react: "19" },
+  },
+  {
+    name: "Deno + React 19 (package.json)",
+    description:
+      "Verifies Recharts renders under Deno with dependencies in package.json (npm compatibility mode)",
+    stability: "stable",
+    type: "direct",
+    packageManager: "deno",
+    integrationPath: "integrations/deno-react19-package-json",
     dependencies: { react: "19" },
   },
   // npm direct dependency tests

--- a/test-ui/server/server.ts
+++ b/test-ui/server/server.ts
@@ -10,6 +10,7 @@ import * as http from "http";
 import { NpmController } from "./scripts/NpmController.ts";
 import { YarnController } from "./scripts/YarnController.ts";
 import { PnpmController } from "./scripts/PnpmController.ts";
+import { DenoController } from "./scripts/DenoController.ts";
 import type { Controller } from "./scripts/Controller.ts";
 import { TestOutcome } from "./scripts/TestOutcome.ts";
 import { getTestMetadata, getAllTests } from "./scripts/test-registry.ts";
@@ -270,6 +271,8 @@ function getControllerFactory(
       return new YarnController(projectPath);
     } else if (packageManager === "pnpm") {
       return new PnpmController(projectPath);
+    } else if (packageManager === "deno") {
+      return new DenoController(projectPath);
     } else {
       throw new Error(`Unknown package manager: ${packageManager}`);
     }


### PR DESCRIPTION
👋 Bartek from the Deno team here.

Follow-up to recharts/recharts#7473 — in [this comment](https://github.com/recharts/recharts/pull/7473#issuecomment-4742409840) @PavelVanecek suggested adding a Deno integration test so Recharts' Deno compatibility is checked on every PR. This adds it.

**Integration** (`integrations/deno-react19/`), mirroring `vite8-react19`: a `deno test` that renders a `BarChart` with `@testing-library/react` in a jsdom environment and asserts an `<svg>` plus the expected 4 `recharts-bar-rectangle` bars. Dependencies (`react`, `react-dom`, `recharts`, `@testing-library/react`) are resolved straight from npm via Deno's `npm:` specifiers — no `npm install` / `node_modules`.

**Harness wiring** so it runs alongside the other integrations:
- `DenoController` — `install` → `deno install`, `test` → `deno task test`, `build` → `deno check`, `verify` → parses `deno.lock`'s `npm` section to assert a single resolved version (handles the `name@version_peer` key format), `pack` → n/a (library tests only)
- `"deno"` added to the `PackageManager` type + a registry entry
- factory branch in `server.ts`

Verified locally: `deno task test` passes (Recharts renders, 4 bars found), `deno install` and `deno check` succeed, and the verify step resolves a single version of react / react-dom / recharts.

Happy to adjust anything — naming, the verify implementation, or the build step.

_This PR was prepared with AI assistance, under human supervision: I review every change myself and personally respond to any comments or review feedback._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Deno support to the integration test runner/controller selection, including new React 19 + Recharts integration coverage (via both `deno.json` and `package.json` paths).
* **Bug Fixes**
  * Improved Deno dependency version resolution by validating a single matching version from the lockfile.
  * Enhanced error reporting by printing captured test output when runs fail.
* **Documentation**
  * Added READMEs with setup and test commands for the new Deno integrations.
* **Chores**
  * Updated CI to install Deno before integration tests and adjusted CI step formatting/ignore files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->