### PR TITLE
deno tests are not passing on recharts main branch, let's move them back to experimental

### DIFF
--- a/test-ui/server/scripts/test-registry.ts
+++ b/test-ui/server/scripts/test-registry.ts
@@ -43,7 +43,7 @@ const directDependencyTests: TestMetadata[] = [
     name: "Deno + React 19 (deno.json)",
     description:
       "Verifies Recharts renders under Deno with dependencies in deno.json (npm: specifiers)",
-    stability: "stable",
+    stability: "experimental",
     type: "direct",
     packageManager: "deno",
     integrationPath: "integrations/deno-react19",
@@ -53,7 +53,7 @@ const directDependencyTests: TestMetadata[] = [
     name: "Deno + React 19 (package.json)",
     description:
       "Verifies Recharts renders under Deno with dependencies in package.json (npm compatibility mode)",
-    stability: "stable",
+    stability: "experimental",
     type: "direct",
     packageManager: "deno",
     integrationPath: "integrations/deno-react19-package-json",


### PR DESCRIPTION
Followup from https://github.com/recharts/recharts-integ/pull/97

@bartlomieju the tests are passing when installing from npm but don't work when installing from tarball which is what the main library CI does: https://github.com/recharts/recharts/pull/7539

How to reproduce:

```
npm pack recharts
./run-test.sh "Deno + React 19 (package.json)" "file://$(pwd)/recharts-3.9.2.tgz"
```

both package.json and deno.json variants fail with different messages.

If I can find some time I will look into it closer but for now I am marking these as experimental which will unblock the main library CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reclassified two Deno + React 19 integration tests from stable to experimental.
  * Updated test categorization so these checks are handled separately from fully stable tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->